### PR TITLE
Add event support

### DIFF
--- a/ZaCherno/ZaCherno.vcxproj
+++ b/ZaCherno/ZaCherno.vcxproj
@@ -79,7 +79,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>ZC_PLATFORM_WINDOWS;ZC_BUILD_DLL;ZC_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>vendor\spdlog\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>src;vendor\spdlog\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -99,7 +99,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>ZC_PLATFORM_WINDOWS;ZC_BUILD_DLL;ZC_RELEASE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>vendor\spdlog\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>src;vendor\spdlog\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -123,7 +123,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>ZC_PLATFORM_WINDOWS;ZC_BUILD_DLL;ZC_DIST;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>vendor\spdlog\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>src;vendor\spdlog\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -141,6 +141,10 @@
     <ClInclude Include="src\ZaCherno\Application.h" />
     <ClInclude Include="src\ZaCherno\Core.h" />
     <ClInclude Include="src\ZaCherno\EntryPoint.h" />
+    <ClInclude Include="src\ZaCherno\Events\ApplicationEvent.h" />
+    <ClInclude Include="src\ZaCherno\Events\Event.h" />
+    <ClInclude Include="src\ZaCherno\Events\KeyEvent.h" />
+    <ClInclude Include="src\ZaCherno\Events\MouseEvent.h" />
     <ClInclude Include="src\ZaCherno\Log.h" />
   </ItemGroup>
   <ItemGroup>

--- a/ZaCherno/ZaCherno.vcxproj.filters
+++ b/ZaCherno/ZaCherno.vcxproj.filters
@@ -4,6 +4,9 @@
     <Filter Include="ZaCherno">
       <UniqueIdentifier>{9F128659-8BDF-E064-B4F8-CE0CA02416F3}</UniqueIdentifier>
     </Filter>
+    <Filter Include="ZaCherno\Events">
+      <UniqueIdentifier>{A3B516D0-0F41-8494-1852-0789845CE094}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\ZaCherno.h" />
@@ -15,6 +18,18 @@
     </ClInclude>
     <ClInclude Include="src\ZaCherno\EntryPoint.h">
       <Filter>ZaCherno</Filter>
+    </ClInclude>
+    <ClInclude Include="src\ZaCherno\Events\ApplicationEvent.h">
+      <Filter>ZaCherno\Events</Filter>
+    </ClInclude>
+    <ClInclude Include="src\ZaCherno\Events\Event.h">
+      <Filter>ZaCherno\Events</Filter>
+    </ClInclude>
+    <ClInclude Include="src\ZaCherno\Events\KeyEvent.h">
+      <Filter>ZaCherno\Events</Filter>
+    </ClInclude>
+    <ClInclude Include="src\ZaCherno\Events\MouseEvent.h">
+      <Filter>ZaCherno\Events</Filter>
     </ClInclude>
     <ClInclude Include="src\ZaCherno\Log.h">
       <Filter>ZaCherno</Filter>

--- a/ZaCherno/cpp.hint
+++ b/ZaCherno/cpp.hint
@@ -1,0 +1,8 @@
+// Hint files help the Visual Studio IDE interpret Visual C++ identifiers
+// such as names of functions and macros.
+// For more information see https://go.microsoft.com/fwlink/?linkid=865984
+#define EVENT_CLASS_TYPE(type) static EventType GetStaticType() {return EventType::##type; } virtual EventType GetEventType() const override { return GetStaticType(); } virtual const char* GetName() const override { return #type; }
+// Hint files help the Visual Studio IDE interpret Visual C++ identifiers
+// such as names of functions and macros.
+// For more information see https://go.microsoft.com/fwlink/?linkid=865984
+#define EVENT_CLASS_CATEGORY(category) virtual int GetCategoryFlags() const override { return category; }

--- a/ZaCherno/src/ZaCherno/Application.cpp
+++ b/ZaCherno/src/ZaCherno/Application.cpp
@@ -1,5 +1,8 @@
 #include "Application.h"
 
+#include "ZaCherno/Events/ApplicationEvent.h"
+#include "ZaCherno/Log.h"
+
 namespace ZaCherno
 {
 
@@ -14,6 +17,10 @@ Application::~Application()	// Destructor
 
 void Application::Run()		// The Applications 'main' function
 {
+
+	WindowResizeEvent e(1280, 720);
+	ZC_TRACE(e);
+
 	while (true);
 }
 

--- a/ZaCherno/src/ZaCherno/Core.h
+++ b/ZaCherno/src/ZaCherno/Core.h
@@ -10,3 +10,6 @@
 #else
 	#error zaCherno only supports 64-bit Windows.
 #endif
+
+// Returns the value of 1 left-shifted by x number of bits
+#define BIT(x) (1 << x)

--- a/ZaCherno/src/ZaCherno/Events/ApplicationEvent.h
+++ b/ZaCherno/src/ZaCherno/Events/ApplicationEvent.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "Event.h"
+
+#include <sstream>
+
+namespace ZaCherno
+{
+
+	class ZACHERNO_API WindowResizeEvent : public Event
+	{
+
+	public:
+		WindowResizeEvent(unsigned int width, unsigned int height)
+			:m_Width(width), m_Height(height) {}
+
+		inline unsigned int GetWidth() const { return m_Width; }
+		inline unsigned int GetHeight() const { return m_Height; }
+
+		std::string ToString() const override
+		{
+			std::stringstream ss;
+			ss << "WindowResizeEvent: " << m_Width << ", " << m_Height;
+			return ss.str();
+		}
+
+		EVENT_CLASS_TYPE(WindowResize)
+		EVENT_CLASS_CATEGORY(EventCategoryApplication)
+
+	private:
+		unsigned int m_Width, m_Height;
+
+	};
+
+	class ZACHERNO_API WindowCloseEvent : public Event
+	{
+	public:
+		WindowCloseEvent() {}
+
+		EVENT_CLASS_TYPE(WindowClose)
+		EVENT_CLASS_CATEGORY(EventCategoryApplication)
+	};
+
+	class ZACHERNO_API AppTickEvent : public Event
+	{
+	public:
+		AppTickEvent() {}
+
+		EVENT_CLASS_TYPE(AppTick)
+			EVENT_CLASS_CATEGORY(EventCategoryApplication)
+	};
+
+	class ZACHERNO_API AppUpdateEvent : public Event
+	{
+	public:
+		AppUpdateEvent() {}
+
+		EVENT_CLASS_TYPE(AppUpdate)
+			EVENT_CLASS_CATEGORY(EventCategoryApplication)
+	};
+
+	class ZACHERNO_API AppRenderEvent : public Event
+	{
+	public:
+		AppRenderEvent() {}
+
+		EVENT_CLASS_TYPE(AppRender)
+			EVENT_CLASS_CATEGORY(EventCategoryApplication)
+	};
+
+}

--- a/ZaCherno/src/ZaCherno/Events/Event.h
+++ b/ZaCherno/src/ZaCherno/Events/Event.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "ZaCherno/Core.h"
+
+#include <string>
+#include <functional>
+
+namespace ZaCherno
+{
+
+	// Events in ZaCherno are blocking/interrupting, meaning they interrupt program flow and must be dealt with then and there.
+	// In the ideal future, they will be dealt with in a separate stage of the programs cycle in an 'event' stage.
+
+	// Used to denote the type of event pertaining to a particular peripheral, software event, or state
+	enum class EventType
+	{
+		None = 0,
+		WindowClose, WindowResize, WindowFocus, WindowLostFocus, WindowMoved,
+		AppTick, AppUpdate, AppRender,
+		KeyPressed, KeyReleased,
+		MouseButtonPressed, MouseButtonReleased, MouseMoved, MouseScrolled
+	};
+
+	// Denotes the possible categories under which EventTypes can be categorised
+	enum EventCategory
+	{
+		None = 0,
+		EventCategoryApplication = BIT(0),
+		EventCategoryInput = BIT(1),
+		EventCategoryKeyboard = BIT(2),
+		EventCategoryMouse = BIT(3),
+		EventCategoryMouseButton = BIT(4)
+	};
+
+// Implements a number of common Event-related methods which override the base implementation by returning the provided EventType
+#define EVENT_CLASS_TYPE(type) static EventType GetStaticType() {return EventType::##type; }\
+								virtual EventType GetEventType() const override { return GetStaticType(); }\
+								virtual const char* GetName() const override { return #type; }
+
+// Implements a constant getter function for returning the categories associated with an Event
+// Takes an integer containing all EventCategory flags which fall under the Event
+#define EVENT_CLASS_CATEGORY(category) virtual int GetCategoryFlags() const override { return category; }
+
+	//Base class for event-type classes to inherit and for dealing with application event-related logic
+	class ZACHERNO_API Event
+	{
+		// Defined a class EventDispatcher
+		friend class EventDispatcher;
+
+	public:
+		virtual EventType GetEventType() const = 0;
+		virtual const char* GetName() const = 0;
+		virtual int GetCategoryFlags() const = 0;
+		virtual std::string ToString() const { return GetName(); }
+
+		inline bool IsInCategory(EventCategory category)
+		{
+			return GetCategoryFlags() & category;
+		}
+
+	protected:
+		bool m_Handled = false;
+
+	};
+
+	// Sub-class of Event for dealing with dispatching of tpye-like events
+	class EventDispatcher
+	{
+		// Following lines define support for callback methods - with name EventFn - for this class only
+
+		template<typename T>
+		// A standard function with a bool return-type that takes any EventType as a parameter
+		using EventFn = std::function<bool(T&)>;
+
+	public:
+		EventDispatcher(Event& event)
+			: m_Event(event) {}
+
+		template<typename T>
+
+		// Following function defines a class
+		bool Dispatch(EventFn<T> func)
+		{
+			// If the type of the given func matches the type of the Event that you're trying to dispatch,
+			// call the function and mark the event as handles
+			if (m_Event.GetEventType() == T::GetStaticType())
+			{
+				m_Event.m_Handled = func(*(T*)&m_Event);
+				return true;
+			}
+			return false;
+		}
+
+	private:
+		Event& m_Event;
+	};
+
+	// Defines a string concatenation operator for Event classes
+	// which appends the Events toString output to the existing outputstream
+	inline std::ostream& operator <<(std::ostream& os, const Event& e)
+	{
+		return os << e.ToString();
+	}
+
+}

--- a/ZaCherno/src/ZaCherno/Events/KeyEvent.h
+++ b/ZaCherno/src/ZaCherno/Events/KeyEvent.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "Event.h"
+
+#include <iostream>
+#include <sstream>
+
+namespace ZaCherno
+{
+
+	// Base class for Key-related events
+	class ZACHERNO_API KeyEvent : public Event
+	{
+
+	public:
+		inline int GetKeyCode() const { return m_KeyCode; }
+
+		EVENT_CLASS_CATEGORY(EventCategoryKeyboard | EventCategoryInput)
+	protected:
+		KeyEvent(int keyCode)
+			: m_KeyCode(keyCode) {}
+
+		int m_KeyCode;
+
+	};
+
+	class ZACHERNO_API KeyPressedEvent : public KeyEvent
+	{
+		
+	public:
+		KeyPressedEvent(int keycode, int repeatCount)
+			: KeyEvent(keycode), m_RepeatCount(repeatCount) {}
+
+		inline int GetRepeatCount() const { return m_RepeatCount; }
+
+		std::string ToString() const override
+		{
+			std::stringstream ss;
+			ss << "KeyPressedEvent: " << m_KeyCode << " (" << m_RepeatCount << " repeats)";
+		}
+
+		EVENT_CLASS_TYPE(KeyPressed)
+	private:
+		int m_RepeatCount;
+	};
+
+	class ZACHERNO_API KeyReleasedEvent : public KeyEvent
+	{
+
+	public:
+		KeyReleasedEvent(int keycode, int repeatCount)
+			: KeyEvent(keycode), m_RepeatCount(repeatCount) {}
+
+		inline int GetRepeatCount() const { return m_RepeatCount; }
+
+		std::string ToString() const override
+		{
+			std::stringstream ss;
+			ss << "KeyReleasedEvent: " << m_KeyCode << " (" << m_RepeatCount << " repeats)";
+		}
+
+		EVENT_CLASS_TYPE(KeyReleased)
+	private:
+		int m_RepeatCount;
+	};
+
+}

--- a/ZaCherno/src/ZaCherno/Events/MouseEvent.h
+++ b/ZaCherno/src/ZaCherno/Events/MouseEvent.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "Event.h"
+
+#include <sstream>
+
+namespace ZaCherno 
+{
+
+	class ZACHERNO_API MouseMovedEvent : public Event
+	{
+
+	public:
+		MouseMovedEvent(float x, float y)
+			: m_MouseX(x), m_MouseY(y) {}
+
+		inline float GetX() const { return m_MouseX; }
+		inline float GetY() const { return m_MouseY; }
+
+		std::string ToString() const override
+		{
+			std::stringstream ss;
+			ss << "MouseMoveEvent: " << m_MouseX << ", " << m_MouseY;
+			return ss.str();
+		}
+
+		EVENT_CLASS_TYPE(MouseMoved)
+		EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput)
+
+	private:
+		float m_MouseX, m_MouseY;
+	};
+
+	class ZACHERNO_API MouseScrolledEvent : public Event
+	{
+
+	public :
+		MouseScrolledEvent(float xOffset, float yOffset)
+			: m_XOffset(xOffset), m_YOffset(yOffset) {}
+
+		inline float GetXOffset() const { return m_XOffset; }
+		inline float GetYOffset() const { return m_YOffset; }
+
+		std::string ToString() const override
+		{
+			std::stringstream ss;
+			ss << "MouseScrolledEvent: " << m_XOffset << ", " << m_YOffset;
+			return ss.str();
+		}
+
+		EVENT_CLASS_TYPE(MouseScrolled)
+		EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput)
+
+	private:
+		float m_XOffset, m_YOffset;
+	};
+
+	class ZACHERNO_API MouseButtonEvent : public Event
+	{
+
+	public:
+		inline int GetMouseButton() const { return m_Button; }
+
+		EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput);
+		
+	protected:
+		MouseButtonEvent(int button)
+			: m_Button(button) {}
+		
+		int m_Button;
+
+	};
+
+	class ZACHERNO_API MouseButtonPressedEvent : public MouseButtonEvent
+	{
+	public:
+		MouseButtonPressedEvent(int button)
+			: MouseButtonEvent(button) {}
+
+		std::string ToString() const override
+		{
+			std::stringstream ss;
+			ss << "MousebuttonPressedEvent: " << m_Button;
+			return ss.str();
+		}
+
+		EVENT_CLASS_TYPE(MouseButtonPressed)
+	};
+
+	class ZACHERNO_API MouseButtonReleasedEvent : public MouseButtonEvent
+	{
+	public:
+		MouseButtonReleasedEvent(int button)
+			: MouseButtonEvent(button) {}
+
+		std::string ToString() const override
+		{
+			std::stringstream ss;
+			ss << "MouseButtonReleasedEvent: " << m_Button;
+			return ss.str();
+		}
+
+		EVENT_CLASS_TYPE(MouseButtonReleased)
+	};
+
+}

--- a/ZaCherno/src/ZaCherno/Log.h
+++ b/ZaCherno/src/ZaCherno/Log.h
@@ -3,6 +3,7 @@
 #include <memory.h>
 #include "Core.h"
 #include "spdlog/spdlog.h"
+#include "spdlog/fmt/ostr.h"	// Allows us to log custom types
 
 namespace ZaCherno
 {

--- a/premake5.lua
+++ b/premake5.lua
@@ -26,6 +26,7 @@ project "ZaCherno"
 
 	includedirs
 	{
+		"%{prj.name}/src",
 		"ZaCherno/vendor/spdlog/include"
 	}
 


### PR DESCRIPTION
- Add basic infrastructure for later implementation of more complex event behaviour.
- Currently implemented is basic debugging features namely event-to-string-concatenation and toString.
- Also, basic event types and categories are added along with classes that make use of them.