### PR TITLE
Implemented use of precompiled headers to build pipeline

### DIFF
--- a/ZaCherno/ZaCherno.vcxproj
+++ b/ZaCherno/ZaCherno.vcxproj
@@ -76,7 +76,8 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>zcpch.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>ZC_PLATFORM_WINDOWS;ZC_BUILD_DLL;ZC_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>src;vendor\spdlog\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -96,7 +97,8 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>zcpch.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>ZC_PLATFORM_WINDOWS;ZC_BUILD_DLL;ZC_RELEASE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>src;vendor\spdlog\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -120,7 +122,8 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Dist|x64'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>zcpch.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>ZC_PLATFORM_WINDOWS;ZC_BUILD_DLL;ZC_DIST;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>src;vendor\spdlog\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -146,10 +149,14 @@
     <ClInclude Include="src\ZaCherno\Events\KeyEvent.h" />
     <ClInclude Include="src\ZaCherno\Events\MouseEvent.h" />
     <ClInclude Include="src\ZaCherno\Log.h" />
+    <ClInclude Include="src\zcpch.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\ZaCherno\Application.cpp" />
     <ClCompile Include="src\ZaCherno\Log.cpp" />
+    <ClCompile Include="src\zcpch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/ZaCherno/ZaCherno.vcxproj.filters
+++ b/ZaCherno/ZaCherno.vcxproj.filters
@@ -34,6 +34,7 @@
     <ClInclude Include="src\ZaCherno\Log.h">
       <Filter>ZaCherno</Filter>
     </ClInclude>
+    <ClInclude Include="src\zcpch.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\ZaCherno\Application.cpp">
@@ -42,5 +43,6 @@
     <ClCompile Include="src\ZaCherno\Log.cpp">
       <Filter>ZaCherno</Filter>
     </ClCompile>
+    <ClCompile Include="src\zcpch.cpp" />
   </ItemGroup>
 </Project>

--- a/ZaCherno/src/ZaCherno/Application.cpp
+++ b/ZaCherno/src/ZaCherno/Application.cpp
@@ -1,3 +1,4 @@
+#include "zcpch.h"
 #include "Application.h"
 
 #include "ZaCherno/Events/ApplicationEvent.h"

--- a/ZaCherno/src/ZaCherno/Events/ApplicationEvent.h
+++ b/ZaCherno/src/ZaCherno/Events/ApplicationEvent.h
@@ -2,8 +2,6 @@
 
 #include "Event.h"
 
-#include <sstream>
-
 namespace ZaCherno
 {
 

--- a/ZaCherno/src/ZaCherno/Events/Event.h
+++ b/ZaCherno/src/ZaCherno/Events/Event.h
@@ -2,9 +2,6 @@
 
 #include "ZaCherno/Core.h"
 
-#include <string>
-#include <functional>
-
 namespace ZaCherno
 {
 

--- a/ZaCherno/src/ZaCherno/Events/KeyEvent.h
+++ b/ZaCherno/src/ZaCherno/Events/KeyEvent.h
@@ -2,9 +2,6 @@
 
 #include "Event.h"
 
-#include <iostream>
-#include <sstream>
-
 namespace ZaCherno
 {
 

--- a/ZaCherno/src/ZaCherno/Events/MouseEvent.h
+++ b/ZaCherno/src/ZaCherno/Events/MouseEvent.h
@@ -2,8 +2,6 @@
 
 #include "Event.h"
 
-#include <sstream>
-
 namespace ZaCherno 
 {
 

--- a/ZaCherno/src/ZaCherno/Log.cpp
+++ b/ZaCherno/src/ZaCherno/Log.cpp
@@ -1,3 +1,4 @@
+#include "zcpch.h"
 #include "Log.h"
 
 #include "spdlog/sinks/stdout_color_sinks.h"

--- a/ZaCherno/src/ZaCherno/Log.h
+++ b/ZaCherno/src/ZaCherno/Log.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory.h>
 #include "Core.h"
 #include "spdlog/spdlog.h"
 #include "spdlog/fmt/ostr.h"	// Allows us to log custom types

--- a/ZaCherno/src/zcpch.cpp
+++ b/ZaCherno/src/zcpch.cpp
@@ -1,0 +1,1 @@
+#include "zcpch.h"

--- a/ZaCherno/src/zcpch.h
+++ b/ZaCherno/src/zcpch.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <iostream>
+#include <memory>
+#include <utility>
+#include <algorithm>
+#include <functional>
+
+#include <string>
+#include <sstream>
+#include <iostream>
+#include <vector>
+#include <unordered_map>
+#include <unordered_set>
+
+#ifdef  ZC_PLATFORM_WINDOWS
+	#include <Windows.h>
+#endif

--- a/premake5.lua
+++ b/premake5.lua
@@ -18,6 +18,9 @@ project "ZaCherno"
 	targetdir ("bin/" .. outputdir .. "/%{prj.name}")
 	objdir ("bin-int/" .. outputdir .. "/%{prj.name}")
 
+	pchheader "zcpch.h"
+	pchsource "ZaCherno/src/zcpch.cpp"
+
 	files
 	{
 		"%{prj.name}/src/**.h",


### PR DESCRIPTION
Add use of precompiled headers into project and premake project file, negating the need for duplicate dependancies.